### PR TITLE
Update README badges to api.runelite.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Visual Metronome ![Total installs](https://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/installs/plugin/visual-metronome)
+# Visual Metronome ![Total installs](https://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/visual-metronome)
 A simple overlay that changes every tick. It displays a box on your screen, displays a number, or displays your true tile that changes every game tick. 
 
 Used for the same purposes as the regular metronome, timing based activities such as PvM or 3-tick fishing. Helpful for if you don't have sound, are listening to music, or just prefer a visual cue.


### PR DESCRIPTION
The website [i.pluginhub.info](https://i.pluginhub.info), which powers your README badges, is going to be shut down at the end of the month (November 1st, 2024) as you can now use RuneLite's API to generate these shields (as was done in this PR).

I highly recommend you merge this PR, or make this change yourself, before the shutdown date to avoid your badges breaking.

You should also create a PR to the hub so that your readme updates on [RuneLite.net's Plugin Hub](https://runelite.net/plugin-hub/show/visual-metronome) website after merging this PR, but that's up to you

Anyway, thanks for using my website while it was alive :heart: