### PR TITLE
Customizable start tick for hotkey resets

### DIFF
--- a/src/main/java/com/visualmetronome/VisualMetronomeConfig.java
+++ b/src/main/java/com/visualmetronome/VisualMetronomeConfig.java
@@ -368,6 +368,21 @@ public interface VisualMetronomeConfig extends Config
 		return Keybind.NOT_SET;
 	}
 
+	@Range(
+		min = 0
+	)
+	@ConfigItem(
+		position = 2,
+		keyName = "tickResetStartTick",
+		name = "Restart on Tick",
+		description = "Choose which tick the hotkey resets the timer to",
+		section = HotkeySettings
+	)
+	default int tickResetStartTick()
+	{
+		return 0;
+	}
+
 	@ConfigSection(
 			name = "Additional Overhead Cycle Settings",
 			description = "Enable additional tick cycles to track",

--- a/src/main/java/com/visualmetronome/VisualMetronomeConfig.java
+++ b/src/main/java/com/visualmetronome/VisualMetronomeConfig.java
@@ -374,7 +374,7 @@ public interface VisualMetronomeConfig extends Config
 	@ConfigItem(
 		position = 2,
 		keyName = "tickResetStartTick",
-		name = "Restart on Tick",
+		name = "Reset to Tick",
 		description = "Choose which tick the hotkey resets the timer to",
 		section = HotkeySettings
 	)

--- a/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
+++ b/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
@@ -170,17 +170,23 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
     {
     }
 
-    @Override
-    public void keyPressed(KeyEvent e)
-    {
-        if (config.tickResetHotkey().matches(e))
-        {
-            tickCounter = 0;
-            tickCounter2 = 0;
-            tickCounter3 = 0;
-            currentColorIndex = 0;
-        }
-    }
+	@Override
+	public void keyPressed(KeyEvent e)
+	{
+		if (config.tickResetHotkey().matches(e)) {
+			//Cycle 1: Prevent out of bounds by setting to max or min value
+			tickCounter = currentColorIndex = Math.min(config.tickResetStartTick(), config.tickCount());
+
+			//Only reset cycles 2 and 3 if their range contains the reset start tick. Otherwise, only cycle 1 will be reset.
+			//Due to the way setting tickCounters 2 and 3 behave, you have to increment by 1 if the reset tick is >0
+			if (config.enableCycle2() && config.tickResetStartTick() <= config.tickCount2()){
+				tickCounter2 = tickCounter;
+			}
+			if (config.enableCycle3() && config.tickResetStartTick() <= config.tickCount3()){
+				tickCounter3 = tickCounter;
+			}
+		}
+	}
 
     @Override
     public void keyReleased(KeyEvent e)

--- a/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
+++ b/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
@@ -48,7 +48,7 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
     protected int tickCounter2 = 0;
     protected int tickCounter3 = 0;
     protected Color currentColor = Color.WHITE;
-
+    protected int resetValue = 0;
     protected Dimension DEFAULT_SIZE = new Dimension(25, 25);
 
     @Provides
@@ -173,17 +173,25 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
-		if (config.tickResetHotkey().matches(e)) {
-			//Cycle 1: Prevent out of bounds by setting to max or min value
-			tickCounter = currentColorIndex = Math.min(config.tickResetStartTick(), config.tickCount());
+		if (config.tickResetHotkey().matches(e))
+        {
+            // Reset Cycle 1
+            if (config.tickCount() > 1)
+            {
+                // Prevent out of bounds by setting to 0 if reset start is above tick count
+                resetValue = (config.tickResetStartTick() >= config.tickCount()) ? 0:config.tickResetStartTick();
+                tickCounter = resetValue;
+                currentColorIndex = 0;
+            }
+            else
+            {
+                resetValue = (config.tickResetStartTick() >= config.colorCycle()) ? 0:config.tickResetStartTick();
+                tickCounter = resetValue;
+                currentColorIndex = resetValue;
+            }
 
-			//Only reset cycles 2 and 3 if their range contains the reset start tick. Otherwise, only cycle 1 will be reset.
-			if (config.enableCycle2() && config.tickResetStartTick() <= config.tickCount2()){
-				tickCounter2 = tickCounter;
-			}
-			if (config.enableCycle3() && config.tickResetStartTick() <= config.tickCount3()){
-				tickCounter3 = tickCounter;
-			}
+            tickCounter2 = (config.tickResetStartTick() >= config.tickCount2()) ? 0:config.tickResetStartTick();
+            tickCounter3 = (config.tickResetStartTick() >= config.tickCount3()) ? 0:config.tickResetStartTick();
 		}
 	}
 

--- a/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
+++ b/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
@@ -172,7 +172,7 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
 
 	@Override
 	public void keyPressed(KeyEvent e)
-	{
+    {
 		if (config.tickResetHotkey().matches(e))
         {
             // Reset Cycle 1
@@ -189,11 +189,10 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
                 tickCounter = resetValue;
                 currentColorIndex = resetValue;
             }
-
             tickCounter2 = (config.tickResetStartTick() >= config.tickCount2()) ? 0:config.tickResetStartTick();
             tickCounter3 = (config.tickResetStartTick() >= config.tickCount3()) ? 0:config.tickResetStartTick();
 		}
-	}
+    }
 
     @Override
     public void keyReleased(KeyEvent e)

--- a/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
+++ b/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
@@ -170,28 +170,28 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
     {
     }
 
-	@Override
-	public void keyPressed(KeyEvent e)
+    @Override
+    public void keyPressed(KeyEvent e)
     {
-		if (config.tickResetHotkey().matches(e))
+        if (config.tickResetHotkey().matches(e))
         {
             // Reset Cycle 1
             if (config.tickCount() > 1)
             {
                 // Prevent out of bounds by setting to 0 if reset start is above tick count
-                resetValue = (config.tickResetStartTick() >= config.tickCount()) ? 0:config.tickResetStartTick();
+                resetValue = (config.tickResetStartTick() >= config.tickCount()) ? 0 : config.tickResetStartTick();
                 tickCounter = resetValue;
                 currentColorIndex = 0;
             }
             else
             {
-                resetValue = (config.tickResetStartTick() >= config.colorCycle()) ? 0:config.tickResetStartTick();
+                resetValue = (config.tickResetStartTick() >= config.colorCycle()) ? 0 : config.tickResetStartTick();
                 tickCounter = resetValue;
                 currentColorIndex = resetValue;
             }
-            tickCounter2 = (config.tickResetStartTick() >= config.tickCount2()) ? 0:config.tickResetStartTick();
-            tickCounter3 = (config.tickResetStartTick() >= config.tickCount3()) ? 0:config.tickResetStartTick();
-		}
+            tickCounter2 = (config.tickResetStartTick() >= config.tickCount2()) ? 0 : config.tickResetStartTick();
+            tickCounter3 = (config.tickResetStartTick() >= config.tickCount3()) ? 0 : config.tickResetStartTick();
+        }
     }
 
     @Override

--- a/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
+++ b/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
@@ -178,7 +178,6 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
 			tickCounter = currentColorIndex = Math.min(config.tickResetStartTick(), config.tickCount());
 
 			//Only reset cycles 2 and 3 if their range contains the reset start tick. Otherwise, only cycle 1 will be reset.
-			//Due to the way setting tickCounters 2 and 3 behave, you have to increment by 1 if the reset tick is >0
 			if (config.enableCycle2() && config.tickResetStartTick() <= config.tickCount2()){
 				tickCounter2 = tickCounter;
 			}


### PR DESCRIPTION
Added customizable hotkey reset tick because in some instances it would be preferred to start on a different tick than 0 (e.g. tick 1 for olm cycles)