### PR TITLE
Adding region based activation feature

### DIFF
--- a/src/main/java/com/visualmetronome/VisualMetronomeConfig.java
+++ b/src/main/java/com/visualmetronome/VisualMetronomeConfig.java
@@ -384,6 +384,106 @@ public interface VisualMetronomeConfig extends Config
 	}
 
 	@ConfigSection(
+			name = "Region-Based Settings",
+			description = "Settings for region-based metronome activation",
+			position = 9
+	)
+	String RegionSettings = "Region Settings";
+
+	@ConfigItem(
+			position = 1,
+			keyName = "enableRegionBased",
+			name = "Enable Region-Based Activation",
+			description = "Only show metronome in specified regions",
+			section = RegionSettings
+	)
+	default boolean enableRegionBased()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 2,
+			keyName = "enableVerzik",
+			name = "Enable in Verzik's Room",
+			description = "Show metronome in Verzik's room (ToB)",
+			section = RegionSettings
+	)
+	default boolean enableVerzik()
+	{
+		return false;
+	}
+
+	@Range(
+			min = 1
+	)
+	@ConfigItem(
+			position = 3,
+			keyName = "verzikTickCount",
+			name = "Verzik Tick Count",
+			description = "Tick count for Verzik's room (default: 7)",
+			section = RegionSettings
+	)
+	default int verzikTickCount()
+	{
+		return 7;
+	}
+
+	@ConfigItem(
+			position = 4,
+			keyName = "enableOlm",
+			name = "Enable in Olm Room",
+			description = "Show metronome in Olm's room (CoX)",
+			section = RegionSettings
+	)
+	default boolean enableOlm()
+	{
+		return false;
+	}
+
+	@Range(
+			min = 1
+	)
+	@ConfigItem(
+			position = 5,
+			keyName = "olmTickCount",
+			name = "Olm Tick Count",
+			description = "Tick count for Olm's room (default: 4)",
+			section = RegionSettings
+	)
+	default int olmTickCount()
+	{
+		return 4;
+	}
+
+	@ConfigItem(
+			position = 6,
+			keyName = "enableFortis",
+			name = "Enable in Fortis Colosseum",
+			description = "Show metronome in Fortis Colosseum",
+			section = RegionSettings
+	)
+	default boolean enableFortis()
+	{
+		return false;
+	}
+
+	@Range(
+			min = 1
+	)
+	@ConfigItem(
+			position = 7,
+			keyName = "fortisTickCount",
+			name = "Fortis Tick Count",
+			description = "Tick count for Fortis Colosseum (default: 6)",
+			section = RegionSettings
+	)
+	default int fortisTickCount()
+	{
+		return 6;
+	}
+
+	@ConfigSection(
 			name = "Additional Overhead Cycle Settings",
 			description = "Enable additional tick cycles to track",
 			position = 9,

--- a/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
+++ b/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
@@ -12,6 +12,9 @@ import net.runelite.client.util.Text;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.chat.QueuedMessage;
+import net.runelite.api.ChatMessageType;
 import javax.inject.Inject;
 import java.awt.event.KeyEvent;
 import java.awt.Color;
@@ -29,10 +32,23 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
     // Region IDs
     private static final int VERZIK_REGION = 12613;
     private static final int OLM_REGION = 12889;
-    private static final int FORTIS_REGION = 14595;
+    private static final int FORTIS_REGION = 7316;
+    
+    // Fortis Colosseum varbit
+    private static final int FORTIS_COLOSSEUM_VARBIT = 13942; // This is a placeholder - we need to find the actual varbit
+    
+    // Fortis Colosseum world coordinates bounds
+    private static final int FORTIS_MIN_X = 1760;
+    private static final int FORTIS_MAX_X = 1850;
+    private static final int FORTIS_MIN_Y = 6080;
+    private static final int FORTIS_MAX_Y = 6150;
+    private static final int FORTIS_PLANE = 0;
 
     @Inject
     private Client client;
+
+    @Inject
+    private ChatMessageManager chatMessageManager;
 
     @Inject
     private OverlayManager overlayManager;
@@ -79,6 +95,35 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
         return client.getLocalPlayer().getWorldLocation().getRegionID() == regionId;
     }
 
+    private boolean isInFortisColosseum()
+    {
+        if (client.getLocalPlayer() == null)
+        {
+            return false;
+        }
+        
+        // Check varbit first (if available)
+        int varbitValue = client.getVarbitValue(FORTIS_COLOSSEUM_VARBIT);
+        if (varbitValue == 1)
+        {
+            return true;
+        }
+        
+        // Check world coordinates as fallback
+        int playerX = client.getLocalPlayer().getLocalLocation().getX();
+        int playerY = client.getLocalPlayer().getLocalLocation().getY();
+        
+        // Debug message to show current coordinates
+        chatMessageManager.queue(QueuedMessage.builder()
+            .type(ChatMessageType.GAMEMESSAGE)
+            .runeLiteFormattedMessage("Player location: X=" + playerX + ", Y=" + playerY)
+            .build());
+        
+        // Check if player is within the Fortis Colosseum bounds
+        return playerX >= FORTIS_MIN_X && playerX <= FORTIS_MAX_X &&
+               playerY >= FORTIS_MIN_Y && playerY <= FORTIS_MAX_Y;
+    }
+
     private void checkRegionChange()
     {
         if (!config.enableRegionBased())
@@ -90,50 +135,136 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
         boolean inOlm = isInRegion(OLM_REGION);
         boolean inFortis = isInRegion(FORTIS_REGION);
 
+        // Debug message to show current region
+        if (client.getLocalPlayer() != null)
+        {
+            int currentRegionId = client.getLocalPlayer().getWorldLocation().getRegionID();
+            chatMessageManager.queue(QueuedMessage.builder()
+                .type(ChatMessageType.GAMEMESSAGE)
+                .runeLiteFormattedMessage("Current region ID: " + currentRegionId)
+                .build());
+        }
+
         if (inVerzik && config.enableVerzik())
         {
             if (!wasInRegion)
             {
-                client.addChatMessage(Text.fromMarkdown("Visual Metronome activated in Verzik's room with " + config.verzikTickCount() + " tick cycle"));
+                chatMessageManager.queue(QueuedMessage.builder()
+                    .type(ChatMessageType.GAMEMESSAGE)
+                    .runeLiteFormattedMessage("Visual Metronome activated in Verzik's room with " + config.verzikTickCount() + " tick cycle")
+                    .build());
                 tickCounter = 0;
                 currentColorIndex = 0;
                 setCurrentColorByColorIndex(1);
             }
             currentRegion = VERZIK_REGION;
             wasInRegion = true;
+            showOverlays();
         }
         else if (inOlm && config.enableOlm())
         {
             if (!wasInRegion)
             {
-                client.addChatMessage(Text.fromMarkdown("Visual Metronome activated in Olm's room with " + config.olmTickCount() + " tick cycle"));
+                chatMessageManager.queue(QueuedMessage.builder()
+                    .type(ChatMessageType.GAMEMESSAGE)
+                    .runeLiteFormattedMessage("Visual Metronome activated in Olm's room with " + config.olmTickCount() + " tick cycle")
+                    .build());
                 tickCounter = 0;
                 currentColorIndex = 0;
                 setCurrentColorByColorIndex(1);
             }
             currentRegion = OLM_REGION;
             wasInRegion = true;
+            showOverlays();
         }
         else if (inFortis && config.enableFortis())
         {
             if (!wasInRegion)
             {
-                client.addChatMessage(Text.fromMarkdown("Visual Metronome activated in Fortis Colosseum with " + config.fortisTickCount() + " tick cycle"));
+                chatMessageManager.queue(QueuedMessage.builder()
+                    .type(ChatMessageType.GAMEMESSAGE)
+                    .runeLiteFormattedMessage("Visual Metronome activated in Fortis Colosseum with " + config.fortisTickCount() + " tick cycle")
+                    .build());
                 tickCounter = 0;
                 currentColorIndex = 0;
                 setCurrentColorByColorIndex(1);
             }
             currentRegion = FORTIS_REGION;
             wasInRegion = true;
+            showOverlays();
         }
         else
         {
             if (wasInRegion)
             {
-                client.addChatMessage(Text.fromMarkdown("Visual Metronome deactivated - left region"));
+                chatMessageManager.queue(QueuedMessage.builder()
+                    .type(ChatMessageType.GAMEMESSAGE)
+                    .runeLiteFormattedMessage("Visual Metronome deactivated - left region")
+                    .build());
             }
             currentRegion = -1;
             wasInRegion = false;
+            hideOverlays();
+        }
+    }
+
+    private void showOverlays()
+    {
+        try
+        {
+            overlayManager.add(overlay);
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Overlay already added
+        }
+
+        try
+        {
+            overlayManager.add(tileOverlay);
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Overlay already added
+        }
+
+        try
+        {
+            overlayManager.add(numberOverlay);
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Overlay already added
+        }
+    }
+
+    private void hideOverlays()
+    {
+        try
+        {
+            overlayManager.remove(overlay);
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Overlay not found
+        }
+
+        try
+        {
+            overlayManager.remove(tileOverlay);
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Overlay not found
+        }
+
+        try
+        {
+            overlayManager.remove(numberOverlay);
+        }
+        catch (IllegalArgumentException e)
+        {
+            // Overlay not found
         }
     }
 
@@ -156,6 +287,15 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
             else if (currentRegion == FORTIS_REGION)
             {
                 currentTickCount = config.fortisTickCount();
+            }
+
+            // Debug message to show current tick count
+            if (currentRegion != -1 && tickCounter == 0)
+            {
+                chatMessageManager.queue(QueuedMessage.builder()
+                    .type(ChatMessageType.GAMEMESSAGE)
+                    .runeLiteFormattedMessage("Current tick count: " + currentTickCount)
+                    .build());
             }
 
             if (tickCounter % currentTickCount == 0)
@@ -226,18 +366,20 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
     {
         DEFAULT_SIZE = new Dimension(config.boxWidth(), config.boxWidth());
         overlay.setPreferredSize(DEFAULT_SIZE);
-        overlayManager.add(overlay);
-        overlayManager.add(tileOverlay);
-        overlayManager.add(numberOverlay);
+        
+        // Only add overlays if region-based is disabled or we're in a valid region
+        if (!config.enableRegionBased())
+        {
+            showOverlays();
+        }
+        
         keyManager.registerKeyListener(this);
     }
 
     @Override
     protected void shutDown() throws Exception
     {
-        overlayManager.remove(overlay);
-        overlayManager.remove(tileOverlay);
-        overlayManager.remove(numberOverlay);
+        hideOverlays();
         tickCounter = 0;
         tickCounter2 = 0;
         tickCounter3 = 0;

--- a/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
+++ b/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
@@ -21,6 +21,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.KeyManager;
+import org.apache.commons.lang3.ArrayUtils;
 
 @PluginDescriptor(
         name = "Visual Metronome",
@@ -30,20 +31,10 @@ import net.runelite.client.input.KeyManager;
 public class VisualMetronomePlugin extends Plugin implements KeyListener
 {
     // Region IDs
-    private static final int VERZIK_REGION = 12613;
-    private static final int OLM_REGION = 12889;
-    private static final int FORTIS_REGION = 7316;
+    private static final int VERZIK_REGION = 12611;
+    private static final int OLM_REGION = 13139;
+    private static final int FORTIS_REGION = 7216;
     
-    // Fortis Colosseum varbit
-    private static final int FORTIS_COLOSSEUM_VARBIT = 13942; // This is a placeholder - we need to find the actual varbit
-    
-    // Fortis Colosseum world coordinates bounds
-    private static final int FORTIS_MIN_X = 1760;
-    private static final int FORTIS_MAX_X = 1850;
-    private static final int FORTIS_MIN_Y = 6080;
-    private static final int FORTIS_MAX_Y = 6150;
-    private static final int FORTIS_PLANE = 0;
-
     @Inject
     private Client client;
 
@@ -92,36 +83,7 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
         {
             return false;
         }
-        return client.getLocalPlayer().getWorldLocation().getRegionID() == regionId;
-    }
-
-    private boolean isInFortisColosseum()
-    {
-        if (client.getLocalPlayer() == null)
-        {
-            return false;
-        }
-        
-        // Check varbit first (if available)
-        int varbitValue = client.getVarbitValue(FORTIS_COLOSSEUM_VARBIT);
-        if (varbitValue == 1)
-        {
-            return true;
-        }
-        
-        // Check world coordinates as fallback
-        int playerX = client.getLocalPlayer().getLocalLocation().getX();
-        int playerY = client.getLocalPlayer().getLocalLocation().getY();
-        
-        // Debug message to show current coordinates
-        chatMessageManager.queue(QueuedMessage.builder()
-            .type(ChatMessageType.GAMEMESSAGE)
-            .runeLiteFormattedMessage("Player location: X=" + playerX + ", Y=" + playerY)
-            .build());
-        
-        // Check if player is within the Fortis Colosseum bounds
-        return playerX >= FORTIS_MIN_X && playerX <= FORTIS_MAX_X &&
-               playerY >= FORTIS_MIN_Y && playerY <= FORTIS_MAX_Y;
+        return ArrayUtils.contains(client.getMapRegions(), regionId);
     }
 
     private void checkRegionChange()
@@ -135,16 +97,6 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
         boolean inOlm = isInRegion(OLM_REGION);
         boolean inFortis = isInRegion(FORTIS_REGION);
 
-        // Debug message to show current region
-        if (client.getLocalPlayer() != null)
-        {
-            int currentRegionId = client.getLocalPlayer().getWorldLocation().getRegionID();
-            chatMessageManager.queue(QueuedMessage.builder()
-                .type(ChatMessageType.GAMEMESSAGE)
-                .runeLiteFormattedMessage("Current region ID: " + currentRegionId)
-                .build());
-        }
-
         if (inVerzik && config.enableVerzik())
         {
             if (!wasInRegion)
@@ -156,10 +108,10 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
                 tickCounter = 0;
                 currentColorIndex = 0;
                 setCurrentColorByColorIndex(1);
+                showOverlays();
             }
             currentRegion = VERZIK_REGION;
             wasInRegion = true;
-            showOverlays();
         }
         else if (inOlm && config.enableOlm())
         {
@@ -172,10 +124,10 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
                 tickCounter = 0;
                 currentColorIndex = 0;
                 setCurrentColorByColorIndex(1);
+                showOverlays();
             }
             currentRegion = OLM_REGION;
             wasInRegion = true;
-            showOverlays();
         }
         else if (inFortis && config.enableFortis())
         {
@@ -188,10 +140,10 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
                 tickCounter = 0;
                 currentColorIndex = 0;
                 setCurrentColorByColorIndex(1);
+                showOverlays();
             }
             currentRegion = FORTIS_REGION;
             wasInRegion = true;
-            showOverlays();
         }
         else
         {
@@ -201,10 +153,10 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
                     .type(ChatMessageType.GAMEMESSAGE)
                     .runeLiteFormattedMessage("Visual Metronome deactivated - left region")
                     .build());
+                hideOverlays();
             }
             currentRegion = -1;
             wasInRegion = false;
-            hideOverlays();
         }
     }
 
@@ -271,45 +223,16 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
     @Subscribe
     public void onGameTick(GameTick tick)
     {
-        checkRegionChange();
-
-        if (!config.enableRegionBased() || currentRegion != -1)
+        if (tickCounter % config.tickCount() == 0)
         {
-            int currentTickCount = config.tickCount();
-            if (currentRegion == VERZIK_REGION)
+            tickCounter = 0;
+            if (currentColorIndex == config.colorCycle())
             {
-                currentTickCount = config.verzikTickCount();
+                currentColorIndex = 0;
             }
-            else if (currentRegion == OLM_REGION)
-            {
-                currentTickCount = config.olmTickCount();
-            }
-            else if (currentRegion == FORTIS_REGION)
-            {
-                currentTickCount = config.fortisTickCount();
-            }
-
-            // Debug message to show current tick count
-            if (currentRegion != -1 && tickCounter == 0)
-            {
-                chatMessageManager.queue(QueuedMessage.builder()
-                    .type(ChatMessageType.GAMEMESSAGE)
-                    .runeLiteFormattedMessage("Current tick count: " + currentTickCount)
-                    .build());
-            }
-
-            if (tickCounter % currentTickCount == 0)
-            {
-                tickCounter = 0;
-                if (currentColorIndex == config.colorCycle())
-                {
-                    currentColorIndex = 0;
-                }
-                setCurrentColorByColorIndex(++currentColorIndex);
-            }
-            tickCounter++;
+            setCurrentColorByColorIndex(++currentColorIndex);
         }
-
+        tickCounter++;
         if (tickCounter2 % config.tickCount2() == 0){
             tickCounter2 = 0;
         }
@@ -357,8 +280,27 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
 
         DEFAULT_SIZE = new Dimension(config.boxWidth(), config.boxWidth());
         
-        // Check region on config change
-        checkRegionChange();
+        // Handle region-based activation toggle
+        if (event.getKey().equals("enableRegionBased"))
+        {
+            if (config.enableRegionBased())
+            {
+                // If enabling region-based, hide overlays by default
+                hideOverlays();
+                // Then check if we're in a valid region
+                checkRegionChange();
+            }
+            else
+            {
+                // If disabling region-based, show overlays
+                showOverlays();
+            }
+        }
+        else
+        {
+            // Check region on other config changes
+            checkRegionChange();
+        }
     }
 
     @Override
@@ -367,7 +309,7 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
         DEFAULT_SIZE = new Dimension(config.boxWidth(), config.boxWidth());
         overlay.setPreferredSize(DEFAULT_SIZE);
         
-        // Only add overlays if region-based is disabled or we're in a valid region
+        // Only add overlays if region-based is disabled
         if (!config.enableRegionBased())
         {
             showOverlays();

--- a/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
+++ b/src/main/java/com/visualmetronome/VisualMetronomePlugin.java
@@ -8,6 +8,10 @@ import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.Text;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.events.GameStateChanged;
 import javax.inject.Inject;
 import java.awt.event.KeyEvent;
 import java.awt.Color;
@@ -22,6 +26,14 @@ import net.runelite.client.input.KeyManager;
 )
 public class VisualMetronomePlugin extends Plugin implements KeyListener
 {
+    // Region IDs
+    private static final int VERZIK_REGION = 12613;
+    private static final int OLM_REGION = 12889;
+    private static final int FORTIS_REGION = 14595;
+
+    @Inject
+    private Client client;
+
     @Inject
     private OverlayManager overlayManager;
 
@@ -49,6 +61,8 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
     protected int tickCounter3 = 0;
     protected Color currentColor = Color.WHITE;
     protected Dimension DEFAULT_SIZE = new Dimension(25, 25);
+    private int currentRegion = -1;
+    private boolean wasInRegion = false;
 
     @Provides
     VisualMetronomeConfig provideConfig(ConfigManager configManager)
@@ -56,19 +70,106 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
         return configManager.getConfig(VisualMetronomeConfig.class);
     }
 
+    private boolean isInRegion(int regionId)
+    {
+        if (client.getLocalPlayer() == null)
+        {
+            return false;
+        }
+        return client.getLocalPlayer().getWorldLocation().getRegionID() == regionId;
+    }
+
+    private void checkRegionChange()
+    {
+        if (!config.enableRegionBased())
+        {
+            return;
+        }
+
+        boolean inVerzik = isInRegion(VERZIK_REGION);
+        boolean inOlm = isInRegion(OLM_REGION);
+        boolean inFortis = isInRegion(FORTIS_REGION);
+
+        if (inVerzik && config.enableVerzik())
+        {
+            if (!wasInRegion)
+            {
+                client.addChatMessage(Text.fromMarkdown("Visual Metronome activated in Verzik's room with " + config.verzikTickCount() + " tick cycle"));
+                tickCounter = 0;
+                currentColorIndex = 0;
+                setCurrentColorByColorIndex(1);
+            }
+            currentRegion = VERZIK_REGION;
+            wasInRegion = true;
+        }
+        else if (inOlm && config.enableOlm())
+        {
+            if (!wasInRegion)
+            {
+                client.addChatMessage(Text.fromMarkdown("Visual Metronome activated in Olm's room with " + config.olmTickCount() + " tick cycle"));
+                tickCounter = 0;
+                currentColorIndex = 0;
+                setCurrentColorByColorIndex(1);
+            }
+            currentRegion = OLM_REGION;
+            wasInRegion = true;
+        }
+        else if (inFortis && config.enableFortis())
+        {
+            if (!wasInRegion)
+            {
+                client.addChatMessage(Text.fromMarkdown("Visual Metronome activated in Fortis Colosseum with " + config.fortisTickCount() + " tick cycle"));
+                tickCounter = 0;
+                currentColorIndex = 0;
+                setCurrentColorByColorIndex(1);
+            }
+            currentRegion = FORTIS_REGION;
+            wasInRegion = true;
+        }
+        else
+        {
+            if (wasInRegion)
+            {
+                client.addChatMessage(Text.fromMarkdown("Visual Metronome deactivated - left region"));
+            }
+            currentRegion = -1;
+            wasInRegion = false;
+        }
+    }
+
     @Subscribe
     public void onGameTick(GameTick tick)
     {
-        if (tickCounter % config.tickCount() == 0)
+        checkRegionChange();
+
+        if (!config.enableRegionBased() || currentRegion != -1)
         {
-            tickCounter = 0;
-            if (currentColorIndex == config.colorCycle())
+            int currentTickCount = config.tickCount();
+            if (currentRegion == VERZIK_REGION)
             {
-                currentColorIndex = 0;
+                currentTickCount = config.verzikTickCount();
             }
-            setCurrentColorByColorIndex(++currentColorIndex);
+            else if (currentRegion == OLM_REGION)
+            {
+                currentTickCount = config.olmTickCount();
+            }
+            else if (currentRegion == FORTIS_REGION)
+            {
+                currentTickCount = config.fortisTickCount();
+            }
+
+            if (tickCounter % currentTickCount == 0)
+            {
+                tickCounter = 0;
+                if (currentColorIndex == config.colorCycle())
+                {
+                    currentColorIndex = 0;
+                }
+                setCurrentColorByColorIndex(++currentColorIndex);
+            }
+            tickCounter++;
         }
-        tickCounter++;
+
         if (tickCounter2 % config.tickCount2() == 0){
             tickCounter2 = 0;
         }
@@ -77,6 +178,15 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
             tickCounter3 = 0;
         }
         tickCounter3++;
+    }
+
+    @Subscribe
+    public void onGameStateChanged(GameStateChanged event)
+    {
+        if (event.getGameState() == GameState.LOGGED_IN)
+        {
+            checkRegionChange();
+        }
     }
 
     @Subscribe
@@ -106,6 +216,9 @@ public class VisualMetronomePlugin extends Plugin implements KeyListener
         }
 
         DEFAULT_SIZE = new Dimension(config.boxWidth(), config.boxWidth());
+        
+        // Check region on config change
+        checkRegionChange();
     }
 
     @Override


### PR DESCRIPTION
This region-based activation feature means that you can still use the visual metronome but it will only appear when you enter an area where you want to use it. This allows you to hide the visual metronome when you're not actively using it, without having to manually turn the plugin off and on. I noticed I only ever really use it for a few bosses and prefer having as little on my screen as possible for the majority of a raid etc, so just thought this would be a neat little additional feature, although quite niche I imagine.

The examples that I have added are:
Fortis - 6 ticks by default, this means that you can correctly set the waves up 
Verzik - 7 ticks - this is to help with tanking, as she attacks on a 7 tick cycle, if you walk under two ticks before she attacks you can '1 tick tank'
Olm - 4 tick cycle, to help with running Olm 

The tick cycle is customisable for each specific region, those are just the defaults.

Tested it and it worked exactly as expected when enabling the region-based activation, the original functionality of the plugin was fine with region-based activation disabled too.

Only thing is, the region_id for the colosseum is 7216, but that's also the region ID for fortis as a whole, so the visual metronome will appear in that area as well as the colosseum. But I can't think of a better way to handle that at this point. 